### PR TITLE
CI fixup

### DIFF
--- a/seirMeasles/DESCRIPTION
+++ b/seirMeasles/DESCRIPTION
@@ -17,7 +17,8 @@ Suggests:
     ggplot2,
     lubridate,
     arrow,
-    withr
+    withr,
+    future
 Config/testthat/edition: 3
 Imports:
     adaptivetau,

--- a/seirMeasles/man/sample_priors.Rd
+++ b/seirMeasles/man/sample_priors.Rd
@@ -15,7 +15,3 @@ Named list of parameter values
 \description{
 Sample the prior distributions
 }
-\details{
-r0 ~ pert(min = 10, mode = 20, max = 60, shape = 5)
-int_eff ~ pert(min = 0, mode = .2, max = .8, shape = 5)
-}


### PR DESCRIPTION
R package build check fails with:
```
❯ checking for unstated dependencies in ‘tests’ ... WARNING
  '::' or ':::' import not declared from: ‘future’
```
solution is to include package `future` as a Suggests dependency